### PR TITLE
Updated the default console handler's format to include LogLevel in output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "logga",
-  "version": "0.1.0",
+  "name": "@stencila/logga",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,14 +40,14 @@ export interface LogHandler {
  * @param level
  */
 function emitLogData(info: LogInfo | string, appName: string, level: LogLevel) {
-  let message
+  let message: string
   if (typeof info === 'object') {
     message = info.message
   } else {
     message = info
   }
 
-  let stackTrace
+  let stackTrace: string
   if (typeof info === 'object' && info.stackTrace) {
     stackTrace = info.stackTrace
   } else {
@@ -71,7 +71,11 @@ export function addHandler(handler?: LogHandler) {
   handler =
     handler ||
     function(data: LogData) {
-      console.error(data.appName + ': ' + data.message)
+      console.error(
+        `${data.appName} - [${LogLevel[data.level].toUpperCase()}] - ${
+          data.message
+        }`
+      )
     }
   // @ts-ignore
   process.on(LOG_EVENT_NAME, handler)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,7 +14,9 @@ test('logga', () => {
   const consoleError = jest.spyOn(console, 'error')
 
   log.debug('a debug message')
-  expect(consoleError).toHaveBeenCalledWith(__filename + ': a debug message')
+  expect(consoleError).toHaveBeenCalledWith(
+    __filename + ' - [DEBUG] - a debug message'
+  )
   expect(events.length).toBe(1)
   expect(events[0].appName).toBe(APPNAME)
   expect(events[0].level).toBe(LogLevel.debug)
@@ -25,7 +27,9 @@ test('logga', () => {
     message: 'a info message',
     stackTrace: 'Just a made up trace'
   })
-  expect(consoleError).toHaveBeenCalledWith(__filename + ': a info message')
+  expect(consoleError).toHaveBeenCalledWith(
+    __filename + ' - [INFO] - a info message'
+  )
   expect(events.length).toBe(2)
   expect(events[1].appName).toBe(APPNAME)
   expect(events[1].level).toBe(LogLevel.info)


### PR DESCRIPTION
Generally logging info will include the log level in the output. This is customisable by the consumer as to if they want this or not, but I have added it into our default console handler.