### PR TITLE
Performance improvements

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -67,8 +67,23 @@ const winstonLogger = winston.createLogger({
   ],
 })
 
-// Run the benchmark suite!
+// Run the benchmark suites!
 
+// A more precise benchmark for comparing performance
+// across changes in code
+new Benchmark.Suite()
+  .add('logga', {
+    minSamples: 500,
+    fn: function () {
+      loggaLogger.error({ msg: 'hello' })
+    },
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .run()
+
+// For comparison with other libraries
 new Benchmark.Suite()
   .add('bole', function () {
     boleLogger.error({ msg: 'hello' })

--- a/benchmark.js
+++ b/benchmark.js
@@ -51,7 +51,7 @@ log4js.configure({
 
 const loggaLogger = logga.getLogger('bench')
 logga.replaceHandlers((entry) => {
-  logga.defaultHandler(entry, { exitOnError: false })
+  logga.defaultHandler(entry, { fastTime: true, exitOnError: false })
 })
 
 const loglevelLogger = loglevel.getLogger('bench')

--- a/benchmark.js
+++ b/benchmark.js
@@ -86,25 +86,25 @@ new Benchmark.Suite()
 // For comparison with other libraries
 new Benchmark.Suite()
   .add('bole', function () {
-    boleLogger.error({ msg: 'hello' })
+    boleLogger.error('derp')
   })
   .add('bunyan', function () {
-    bunyanLogger.error({ msg: 'hello' })
+    bunyanLogger.error('derp')
   })
   .add('logga', function () {
-    loggaLogger.error({ msg: 'hello' })
+    loggaLogger.error('derp')
   })
   .add('log4js', function () {
-    log4jsLogger.error({ msg: 'hello' })
+    log4jsLogger.error('derp')
   })
   .add('loglevel', function () {
-    loglevelLogger.error({ msg: 'hello' })
+    loglevelLogger.error('derp')
   })
   .add('pino', function () {
-    pinoLogger.error({ msg: 'hello' })
+    pinoLogger.error('derp')
   })
   .add('winston', function () {
-    winstonLogger.error({ msg: 'hello' })
+    winstonLogger.error('derp')
   })
   .on('cycle', function (event) {
     console.log(String(event.target))

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,100 @@
+/**
+ * Benchmarks comparing the speed of Logga to other Node.js logging frameworks
+ *
+ * All frameworks configured to log errors to `stderr`.
+ * Build Logga if necessary before running benchmarks.
+ * Best run by redireting `stderr` to `/dev/null` e.g.
+ *
+ * ```sh
+ * npm run benchmark
+ * ```
+ */
+
+const Benchmark = require('benchmark')
+
+// Import each of the libraries used
+
+const bole = require('bole')
+const bunyan = require('bunyan')
+const log4js = require('log4js')
+const logga = require('.')
+const loglevel = require('loglevel')
+const pino = require('pino')
+const winston = require('winston')
+
+// Instantiate loggers for each library
+
+const boleLogger = bole('bench')
+bole
+  .output({
+    level: 'error',
+    stream: process.stderr,
+  })
+  .setFastTime(true)
+
+const bunyanLogger = bunyan.createLogger({
+  name: 'bench',
+  streams: [
+    {
+      level: 'error',
+      stream: process.stderr,
+    },
+  ],
+})
+
+var log4jsLogger = log4js.getLogger()
+log4jsLogger.level = 'error'
+log4js.configure({
+  appenders: { err: { type: 'stderr' } },
+  categories: { default: { appenders: ['err'], level: 'ERROR' } },
+})
+
+const loggaLogger = logga.getLogger('bench')
+logga.replaceHandlers((entry) => {
+  logga.defaultHandler(entry, { exitOnError: false })
+})
+
+const loglevelLogger = loglevel.getLogger('bench')
+loglevelLogger.setLevel('error')
+
+const pinoLogger = pino(process.stderr, { name: 'bench' })
+
+const winstonLogger = winston.createLogger({
+  transports: [
+    new winston.transports.Stream({
+      stream: process.stderr,
+    }),
+  ],
+})
+
+// Run the benchmark suite!
+
+new Benchmark.Suite()
+  .add('bole', function () {
+    boleLogger.error({ msg: 'hello' })
+  })
+  .add('bunyan', function () {
+    bunyanLogger.error({ msg: 'hello' })
+  })
+  .add('logga', function () {
+    loggaLogger.error({ msg: 'hello' })
+  })
+  .add('log4js', function () {
+    log4jsLogger.error({ msg: 'hello' })
+  })
+  .add('loglevel', function () {
+    loglevelLogger.error({ msg: 'hello' })
+  })
+  .add('pino', function () {
+    pinoLogger.error({ msg: 'hello' })
+  })
+  .add('winston', function () {
+    winstonLogger.error({ msg: 'hello' })
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run()

--- a/benchmark.js
+++ b/benchmark.js
@@ -75,7 +75,7 @@ new Benchmark.Suite()
   .add('logga', {
     minSamples: 500,
     fn: function () {
-      loggaLogger.error({ msg: 'hello' })
+      loggaLogger.error('derp')
     },
   })
   .on('cycle', function (event) {

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,13 +1,22 @@
 /**
  * Benchmarks comparing the speed of Logga to other Node.js logging frameworks
  *
+ * First install the benchmark and logging libraries
+ *
+ * ```sh
+ * npm install --no-save benchmark bole bunyan log4js loglevel pino winston
+ * ```
+ *
+ * Then to rebuild Logga and run the benchmarks,
+ *
+ * ```sh
+ * npm run bench
+ * ```
+ *
  * All frameworks configured to log errors to `stderr`.
  * Build Logga if necessary before running benchmarks.
  * Best run by redireting `stderr` to `/dev/null` e.g.
  *
- * ```sh
- * npm run benchmark
- * ```
  */
 
 const Benchmark = require('benchmark')

--- a/example.js
+++ b/example.js
@@ -29,6 +29,6 @@ try {
   const { message, stack } = error
   log.error({
     message: 'Woaaah something bad happened! ' + message,
-    stack
+    stack,
   })
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+import { LogHandler } from './index'
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      _logga?: LogHandler[]
+    }
+  }
+
+  interface Window {
+    _logga?: LogHandler[]
+  }
+}

--- a/index.test.ts
+++ b/index.test.ts
@@ -9,6 +9,11 @@ import {
   defaultHandler,
 } from './index'
 
+const spyOnWriter = () =>
+  typeof process !== 'undefined'
+    ? jest.spyOn(process.stderr, 'write')
+    : jest.spyOn(console, 'error')
+
 test('logging', () => {
   const TAG = 'tests:logging'
   const log = getLogger(TAG)
@@ -51,7 +56,7 @@ test('TTY', () => {
 
   // Fake that we are using a TTY device
   process.stderr.isTTY = true
-  const consoleError = jest.spyOn(console, 'error')
+  const consoleError = spyOnWriter()
 
   log.error('an error message')
 
@@ -67,7 +72,7 @@ test('non-TTY', () => {
   // Fake that we are using a non-TTY device
   // @ts-ignore
   process.stderr.isTTY = false
-  const consoleError = jest.spyOn(console, 'error')
+  const consoleError = spyOnWriter()
 
   let error = new Error('an error message')
   log.error(error)
@@ -82,7 +87,7 @@ test('non-TTY', () => {
 
 test('adding and removing handlers', () => {
   const log = getLogger('tests:handlers')
-  const consoleError = jest.spyOn(console, 'error')
+  const consoleError = spyOnWriter()
   const consoleErrorCalls = consoleError.mock.calls.length
   const events: LogData[] = []
 
@@ -180,7 +185,7 @@ test('adding a handler with filter options', () => {
 test('defaultHandler:maxLevel', () => {
   const log = getLogger('logger')
 
-  const consoleError = jest.spyOn(console, 'error')
+  const consoleError = spyOnWriter()
   const callsStart = consoleError.mock.calls.length
 
   log.debug('a debug message')
@@ -201,7 +206,7 @@ test('defaultHandler:maxLevel', () => {
 test('defaultHandler:throttle', async () => {
   const log = getLogger('logger')
 
-  const consoleError = jest.spyOn(console, 'error')
+  const consoleError = spyOnWriter()
   const callsStart = consoleError.mock.calls.length
 
   replaceHandlers((data) =>

--- a/index.test.ts
+++ b/index.test.ts
@@ -36,7 +36,8 @@ test('logging', () => {
   log.warn('a warning message')
   expect(events[2].level).toBe(LogLevel.warn)
 
-  log.error('an error message')
+  let error = new Error('an error message')
+  log.error(error)
   expect(events[3].level).toBe(LogLevel.error)
   expect(events[3].stack).toMatch(/^Error:/)
   // Second line (first call stack) in stack trace should be this file
@@ -68,7 +69,8 @@ test('non-TTY', () => {
   process.stderr.isTTY = false
   const consoleError = jest.spyOn(console, 'error')
 
-  log.error('an error message')
+  let error = new Error('an error message')
+  log.error(error)
 
   const json = consoleError.mock.calls[consoleError.mock.calls.length - 1][0]
   const data = JSON.parse(json)

--- a/index.test.ts
+++ b/index.test.ts
@@ -56,7 +56,7 @@ test('TTY', () => {
 
   // Fake that we are using a TTY device
   process.stderr.isTTY = true
-  const consoleError = spyOnWriter()
+  const consoleError = jest.spyOn(console, 'error')
 
   log.error('an error message')
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -103,9 +103,9 @@ test('exit on error', () => {
   const log = getLogger('tests:exit-on-error')
   replaceHandlers((data) => defaultHandler(data, { exitOnError: true }))
 
-  // @ts-ignore
   const mockExit = jest
     .spyOn(process, 'exit')
+    // @ts-ignore
     .mockImplementation((code?: number): never => {})
   log.error('an error message')
   expect(mockExit).toHaveBeenCalledWith(1)

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,9 @@ const root =
     ? window
     : typeof global !== 'undefined'
     ? global
-    : {}
+    : // Ignore in coverage because is expected to be unreachable
+      // istanbul ignore next
+      {}
 
 function Logga(): LogHandler[] {
   const name = '_logga'
@@ -185,28 +187,27 @@ const defaultHandlerHistory = new Map<string, number>()
  * @param value The string to escape
  */
 export function escape(value: string): string {
-  return value !== undefined
-    ? value.replace(/"|\\|\/|\f|\n|\r|\t/g, (char) => {
-        switch (char) {
-          case '"':
-            return '"'
-          case '\\':
-            return '\\\\'
-          case '/':
-            return '\\/'
-          case '\f':
-            return '\\f'
-          case '\n':
-            return '\\n'
-          case '\r':
-            return '\\r'
-          case '\t':
-            return '\\t'
-        }
-        // istanbul ignore next
-        return char
-      })
-    : value
+  return value.replace(/"|\\|\/|\f|\n|\r|\t/g, (char) => {
+    switch (char) {
+      case '"':
+        return '"'
+      case '\\':
+        return '\\\\'
+      case '/':
+        return '\\/'
+      case '\f':
+        return '\\f'
+      case '\n':
+        return '\\n'
+      case '\r':
+        return '\\r'
+      case '\t':
+        return '\\t'
+    }
+    // Ignore in coverage because is expected to be unreachable
+    // istanbul ignore next
+    return char
+  })
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -312,7 +312,14 @@ export function defaultHandler(
     const { showStack = false } = options
     if (showStack && stack !== undefined) entry += '\n  ' + stack
   }
-  console.error(entry)
+
+  // On Node.js, writing directly to stderr provides a performance boost
+  // of ~ 150% (based on our benchmarking)
+  if (typeof process !== 'undefined') {
+    process.stderr.write(entry + '\n')
+  } else {
+    console.error(entry)
+  }
 
   const { exitOnError = true } = options
   if (

--- a/index.ts
+++ b/index.ts
@@ -1,23 +1,4 @@
-var root =
-  typeof window !== 'undefined'
-    ? window
-    : typeof global !== 'undefined'
-    ? global
-    : {}
-
-function Logga() {
-  const name = '_logga'
-  if (name in root) {
-    // @ts-ignore
-    return root[name]
-  }
-  // @ts-ignore
-  root[name] = []
-  // @ts-ignore
-  return root[name]
-}
-
-const logga: LogHandler[] = Logga()
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 
 /**
  * The severity level of a log event.
@@ -65,6 +46,29 @@ export interface LogHandler {
   (data: LogData): void
 }
 
+// Global `logga` instance
+
+const root =
+  typeof window !== 'undefined'
+    ? window
+    : typeof global !== 'undefined'
+    ? global
+    : {}
+
+function Logga(): LogHandler[] {
+  const name = '_logga'
+  if (name in root) {
+    // @ts-ignore
+    return root[name] as LogHandler[]
+  }
+  // @ts-ignore
+  root[name] = []
+  // @ts-ignore
+  return root[name] as LogHandler[]
+}
+
+const logga: LogHandler[] = Logga()
+
 /**
  * Take a message `string`, or `LogInfo` object,
  * and emit an event with a `LogData` object.
@@ -77,14 +81,14 @@ function emitLogData(
   tag: string,
   level: LogLevel
 ): void {
-  let message =
+  const message =
     typeof info === 'string'
       ? info
       : typeof info === 'object'
       ? info?.message ?? ''
       : ''
 
-  let stack = typeof info === 'object' ? info?.stack : undefined
+  const stack = typeof info === 'object' ? info?.stack : undefined
 
   const data: LogData = { tag, level, message, stack }
 
@@ -181,7 +185,7 @@ const defaultHandlerHistory = new Map<string, number>()
  */
 function escape(value: string): string {
   return value !== undefined
-    ? value.replace(/\"|\\|\/|\f|\n|\r|\t/g, (char) => {
+    ? value.replace(/"|\\|\/|\f|\n|\r|\t/g, (char) => {
         switch (char) {
           case '"':
             return '"'

--- a/index.ts
+++ b/index.ts
@@ -124,9 +124,6 @@ if (typeof window !== 'undefined') {
  * Take a message `string`, or `LogInfo` object,
  * and emit an event with a `LogData` object.
  *
- * For `LogLevel.error`, if `LogInfo` does not have a `stack`,
- * one is generated and set on the `LogData`.
- *
  * @param info
  * @param level
  */
@@ -135,26 +132,17 @@ function emitLogData(
   tag: string,
   level: LogLevel
 ): void {
-  let message = ''
-  if (typeof info === 'object' && info.message !== undefined) {
-    message = info.message
-  } else if (typeof info === 'string') {
-    message = info
-  }
+  let message =
+    typeof info === 'string'
+      ? info
+      : typeof info === 'object'
+      ? info?.message ?? ''
+      : ''
 
-  const data: LogData = { tag, level, message }
+  let stack = typeof info === 'object' ? info?.stack : undefined
 
-  if (typeof info === 'object' && info.stack !== undefined) {
-    data.stack = info.stack
-  } else if (level <= LogLevel.error) {
-    const error = new Error()
-    if (error.stack !== undefined) {
-      // Remove the first three lines of the stack trace which
-      // are not useful (see issue #3)
-      const lines = error.stack.split('\n')
-      data.stack = [lines[0], ...lines.slice(3)].join('\n')
-    }
-  }
+  const data: LogData = { tag, level, message, stack }
+
   bus.emit(LOG_EVENT_NAME, data)
 }
 

--- a/index.ts
+++ b/index.ts
@@ -245,6 +245,7 @@ export function defaultHandler(
   data: LogData,
   options: {
     maxLevel?: LogLevel
+    fastTime?: boolean
     showStack?: boolean
     exitOnError?: boolean
     throttle?: {
@@ -284,7 +285,11 @@ export function defaultHandler(
     process.stderr !== undefined &&
     process.stderr.isTTY !== true
   ) {
-    entry = JSON.stringify({ time: new Date().toISOString(), ...data })
+    const { fastTime = false } = options
+    entry = JSON.stringify({
+      time: fastTime ? Date.now() : new Date().toISOString(),
+      ...data,
+    })
   } else {
     const index = level < 0 ? 0 : level > 3 ? 3 : level
     const label = LogLevel[index].toUpperCase().padEnd(5, ' ')

--- a/index.ts
+++ b/index.ts
@@ -48,26 +48,23 @@ export interface LogHandler {
 
 // Global `logga` instance
 
-const root =
+const root: NodeJS.Global | Window =
   typeof window !== 'undefined'
     ? window
     : typeof global !== 'undefined'
     ? global
     : // Ignore in coverage because is expected to be unreachable
       // istanbul ignore next
-      {}
+      ({} as typeof global)
 
 function Logga(): LogHandler[] {
   const name = '_logga'
   if (name in root) {
-    // istanbul ignore next
-    // @ts-ignore
-    return root[name] as LogHandler[]
+    return root[name] ?? []
   }
-  // @ts-ignore
+
   root[name] = []
-  // @ts-ignore
-  return root[name] as LogHandler[]
+  return root[name] ?? []
 }
 
 const logga: LogHandler[] = Logga()
@@ -334,7 +331,6 @@ if (handlers().length === 0) addHandler(defaultHandler)
  *
  * @param tag The unique application or package name
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function getLogger(tag: string): Logger {
   return {
     error(message: string | LogEvent) {

--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,7 @@ const root =
 function Logga(): LogHandler[] {
   const name = '_logga'
   if (name in root) {
+    // istanbul ignore next
     // @ts-ignore
     return root[name] as LogHandler[]
   }
@@ -183,7 +184,7 @@ const defaultHandlerHistory = new Map<string, number>()
  *
  * @param value The string to escape
  */
-function escape(value: string): string {
+export function escape(value: string): string {
   return value !== undefined
     ? value.replace(/"|\\|\/|\f|\n|\r|\t/g, (char) => {
         switch (char) {
@@ -202,6 +203,7 @@ function escape(value: string): string {
           case '\t':
             return '\\t'
         }
+        // istanbul ignore next
         return char
       })
     : value
@@ -280,7 +282,7 @@ export function defaultHandler(
     const index = level < 0 ? 0 : level > 3 ? 3 : level
     const label = LogLevel[index].toUpperCase().padEnd(5, ' ')
     let line
-    /* istanbul ignore next */
+    // istanbul ignore next
     if (typeof window !== 'undefined') {
       line = `${label} ${tag} ${message}`
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,17 +1536,6 @@
       "integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
       "dev": true
     },
-    "@dabh/diagnostics": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-      "dev": true,
-      "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
-    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -3335,12 +3324,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true
-    },
     "autoprefixer": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.1.0.tgz",
@@ -3586,31 +3569,11 @@
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
     },
-    "benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
-    },
-    "bole": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bole/-/bole-4.0.0.tgz",
-      "integrity": "sha512-Bk/2qoyOSlwU1dnDFk/oPM2FCNKAlYlBHfpAgwGX+K9HUtxSvmIAQCmMWMOvE6BlHHRCwsH1MxJe/r1ieodxqQ==",
-      "dev": true,
-      "requires": {
-        "fast-safe-stringify": "^2.0.7",
-        "individual": "^3.0.0"
-      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -3700,18 +3663,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
       "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
       "dev": true
-    },
-    "bunyan": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-      "dev": true,
-      "requires": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -4102,28 +4053,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
-    },
-    "colorspace": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
-      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
-      "dev": true,
-      "requires": {
-        "color": "3.0.x",
-        "text-hex": "1.0.x"
-      },
-      "dependencies": {
-        "color": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-          "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
-          }
-        }
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -4828,12 +4757,6 @@
         "whatwg-url": "^8.0.0"
       }
     },
-    "date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
-      "dev": true
-    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -5108,16 +5031,6 @@
         "is-obj": "^2.0.0"
       }
     },
-    "dtrace-provider": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.14.0"
-      }
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -5171,12 +5084,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
-    },
-    "enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "dev": true
     },
     "end-of-stream": {
@@ -5980,18 +5887,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
-      "dev": true
-    },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
-    },
     "fastq": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
@@ -6009,12 +5904,6 @@
       "requires": {
         "bser": "2.1.1"
       }
-    },
-    "fecha": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
-      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
-      "dev": true
     },
     "figures": {
       "version": "3.2.0",
@@ -6181,22 +6070,10 @@
         "rimraf": "^3.0.2"
       }
     },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
     "flatted": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
       "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
-      "dev": true
-    },
-    "fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
     "for-in": {
@@ -7075,12 +6952,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-      "dev": true
-    },
-    "individual": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
-      "integrity": "sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0=",
       "dev": true
     },
     "inflight": {
@@ -8323,12 +8194,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8496,46 +8361,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-      "dev": true
-    },
-    "log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
-      "dev": true,
-      "requires": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
-      },
-      "dependencies": {
-        "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-          "dev": true
-        }
-      }
-    },
-    "logform": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
-      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
-      "dev": true,
-      "requires": {
-        "colors": "^1.2.1",
-        "fast-safe-stringify": "^2.0.4",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "triple-beam": "^1.3.0"
-      }
-    },
-    "loglevel": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
-      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
     },
     "loose-envify": {
@@ -9206,13 +9031,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true,
-      "optional": true
-    },
     "mri": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
@@ -9252,51 +9070,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^6.0.1"
-          }
-        }
-      }
-    },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
-    },
     "nanoid": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -9327,13 +9100,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "dev": true,
-      "optional": true
     },
     "neo-async": {
       "version": "2.6.2",
@@ -13145,15 +12911,6 @@
         "wrappy": "1"
       }
     },
-    "one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dev": true,
-      "requires": {
-        "fn.name": "1.x.x"
-      }
-    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -13457,26 +13214,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pino": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.10.0.tgz",
-      "integrity": "sha512-ZFGE/Wq930gFb1h0RI6S/QOfkyzNj94Xubwlyo4XpxNUgrG1C0iEqnlooG5Fymx6yrUUtEJ8j/u8NCGwgwTXaQ==",
-      "dev": true,
-      "requires": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "quick-format-unescaped": "^4.0.1",
-        "sonic-boom": "^1.0.2"
-      }
-    },
-    "pino-std-serializers": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.1.0.tgz",
-      "integrity": "sha512-Fk1pxhX6tuW4ozRDFw5Mz/IHQV5wXYXZwjG/gOpTNPCbYEMeNW9VnKAEu1428CwAQVupFruOr1vkC/ufmcwedA==",
-      "dev": true
-    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -13595,12 +13332,6 @@
       "requires": {
         "find-up": "^2.1.0"
       }
-    },
-    "platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.2.0",
@@ -15660,12 +15391,6 @@
         }
       }
     },
-    "quick-format-unescaped": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
-      "dev": true
-    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -16112,12 +15837,6 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
-    "rfdc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
-      "dev": true
-    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -16354,13 +16073,6 @@
       "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
       "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
       "dev": true
-    },
-    "safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "dev": true,
-      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -17194,16 +16906,6 @@
         }
       }
     },
-    "sonic-boom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
-      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
-      "dev": true,
-      "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
-    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -17364,12 +17066,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "dev": true
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "stack-utils": {
@@ -17781,25 +17477,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
-      "dev": true,
-      "requires": {
-        "date-format": "^2.1.0",
-        "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
-      },
-      "dependencies": {
-        "date-format": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
-          "dev": true
-        }
-      }
-    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -18187,12 +17864,6 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
-    "text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -18384,12 +18055,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
-    },
-    "triple-beam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-      "dev": true
     },
     "ts-jest": {
       "version": "26.4.4",
@@ -18889,52 +18554,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
-    },
-    "winston": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
-      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
-      "dev": true,
-      "requires": {
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.1.0",
-        "is-stream": "^2.0.0",
-        "logform": "^2.2.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "winston-transport": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.3.7",
-        "triple-beam": "^1.2.0"
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3702,9 +3702,9 @@
       "dev": true
     },
     "bunyan": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
-      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
       "dev": true,
       "requires": {
         "dtrace-provider": "~0.8",
@@ -4103,8 +4103,6 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
-<<<<<<< master
-=======
     "colorspace": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
@@ -4127,7 +4125,6 @@
         }
       }
     },
->>>>>>> perf(Benchmarks): Add benchmarking script
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -6559,7 +6556,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gzip-size": {
       "version": "6.0.0",
@@ -7492,6 +7490,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -9386,6 +9385,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -16878,7 +16878,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shiki": {
       "version": "0.2.7",
@@ -18748,7 +18749,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,6 +1536,17 @@
       "integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
       "dev": true
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -3324,6 +3335,12 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true
+    },
     "autoprefixer": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.1.0.tgz",
@@ -3569,11 +3586,31 @@
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bole": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bole/-/bole-4.0.0.tgz",
+      "integrity": "sha512-Bk/2qoyOSlwU1dnDFk/oPM2FCNKAlYlBHfpAgwGX+K9HUtxSvmIAQCmMWMOvE6BlHHRCwsH1MxJe/r1ieodxqQ==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.7",
+        "individual": "^3.0.0"
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -3663,6 +3700,18 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
       "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
       "dev": true
+    },
+    "bunyan": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
+      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
+      "dev": true,
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -4054,6 +4103,31 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
+<<<<<<< master
+=======
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "dev": true,
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      },
+      "dependencies": {
+        "color": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+          "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        }
+      }
+    },
+>>>>>>> perf(Benchmarks): Add benchmarking script
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4757,6 +4831,12 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "dev": true
+    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -5031,6 +5111,16 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -5084,6 +5174,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "dev": true
     },
     "end-of-stream": {
@@ -5887,6 +5983,18 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
@@ -5904,6 +6012,12 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+      "dev": true
     },
     "figures": {
       "version": "3.2.0",
@@ -6070,10 +6184,22 @@
         "rimraf": "^3.0.2"
       }
     },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+      "dev": true
+    },
     "flatted": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
       "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+      "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
     "for-in": {
@@ -6951,6 +7077,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "individual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
+      "integrity": "sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0=",
       "dev": true
     },
     "inflight": {
@@ -8192,6 +8324,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8359,6 +8497,46 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
+    "log4js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "dev": true,
+      "requires": {
+        "date-format": "^3.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.1",
+        "rfdc": "^1.1.4",
+        "streamroller": "^2.2.4"
+      },
+      "dependencies": {
+        "flatted": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+          "dev": true
+        }
+      }
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "loglevel": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
     },
     "loose-envify": {
@@ -9029,6 +9207,13 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true,
+      "optional": true
+    },
     "mri": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
@@ -9068,6 +9253,51 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -9098,6 +9328,13 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true,
+      "optional": true
     },
     "neo-async": {
       "version": "2.6.2",
@@ -12908,6 +13145,15 @@
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "requires": {
+        "fn.name": "1.x.x"
+      }
+    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -13211,6 +13457,26 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.10.0.tgz",
+      "integrity": "sha512-ZFGE/Wq930gFb1h0RI6S/QOfkyzNj94Xubwlyo4XpxNUgrG1C0iEqnlooG5Fymx6yrUUtEJ8j/u8NCGwgwTXaQ==",
+      "dev": true,
+      "requires": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.1.0.tgz",
+      "integrity": "sha512-Fk1pxhX6tuW4ozRDFw5Mz/IHQV5wXYXZwjG/gOpTNPCbYEMeNW9VnKAEu1428CwAQVupFruOr1vkC/ufmcwedA==",
+      "dev": true
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -13329,6 +13595,12 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.2.0",
@@ -15388,6 +15660,12 @@
         }
       }
     },
+    "quick-format-unescaped": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+      "dev": true
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -15834,6 +16112,12 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+      "dev": true
+    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -16070,6 +16354,13 @@
       "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
       "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
       "dev": true
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "dev": true,
+      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -16902,6 +17193,16 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
+      "dev": true,
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -17062,6 +17363,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "stack-utils": {
@@ -17473,6 +17780,25 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "streamroller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "dev": true,
+      "requires": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+          "dev": true
+        }
+      }
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -17860,6 +18186,12 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -18051,6 +18383,12 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
+      "dev": true
     },
     "ts-jest": {
       "version": "26.4.4",
@@ -18549,6 +18887,52 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "dev": true,
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -42,18 +42,11 @@
   "devDependencies": {
     "@stencila/dev-config": "1.4.129",
     "@types/jest": "26.0.20",
-    "benchmark": "2.1.4",
-    "bole": "4.0.0",
-    "bunyan": "1.8.15",
     "jest": "26.6.3",
-    "log4js": "6.3.0",
-    "loglevel": "1.7.1",
     "microbundle": "0.13.0",
-    "pino": "6.10.0",
     "ts-jest": "26.4.4",
     "typedoc": "0.20.14",
-    "typescript": "4.1.3",
-    "winston": "3.3.3"
+    "typescript": "4.1.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -40,30 +40,20 @@
   },
   "homepage": "https://github.com/stencila/logga#readme",
   "devDependencies": {
-<<<<<<< master
     "@stencila/dev-config": "1.4.129",
     "@types/jest": "26.0.20",
-=======
-    "@stencila/dev-config": "1.4.119",
-    "@types/jest": "26.0.19",
     "benchmark": "2.1.4",
     "bole": "4.0.0",
-    "bunyan": "1.8.14",
->>>>>>> perf(Benchmarks): Add benchmarking script
+    "bunyan": "1.8.15",
     "jest": "26.6.3",
     "log4js": "6.3.0",
     "loglevel": "1.7.1",
     "microbundle": "0.13.0",
     "pino": "6.10.0",
     "ts-jest": "26.4.4",
-<<<<<<< master
     "typedoc": "0.20.14",
-    "typescript": "4.1.3"
-=======
-    "typedoc": "0.19.2",
     "typescript": "4.1.3",
     "winston": "3.3.3"
->>>>>>> perf(Benchmarks): Add benchmarking script
   },
   "jest": {
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "npm run build:node && npm run build:browser",
     "build:node": "microbundle build --target node --format es,cjs -o dist/lib",
     "build:browser": "microbundle build --name logga --format es,umd -o dist/browser",
+    "bench": "npm run build:node && node benchmark.js 2>/dev/null",
     "docs": "typedoc --mode file --out docs index.ts && cp *.png docs/"
   },
   "repository": {
@@ -39,13 +40,30 @@
   },
   "homepage": "https://github.com/stencila/logga#readme",
   "devDependencies": {
+<<<<<<< master
     "@stencila/dev-config": "1.4.129",
     "@types/jest": "26.0.20",
+=======
+    "@stencila/dev-config": "1.4.119",
+    "@types/jest": "26.0.19",
+    "benchmark": "2.1.4",
+    "bole": "4.0.0",
+    "bunyan": "1.8.14",
+>>>>>>> perf(Benchmarks): Add benchmarking script
     "jest": "26.6.3",
+    "log4js": "6.3.0",
+    "loglevel": "1.7.1",
     "microbundle": "0.13.0",
+    "pino": "6.10.0",
     "ts-jest": "26.4.4",
+<<<<<<< master
     "typedoc": "0.20.14",
     "typescript": "4.1.3"
+=======
+    "typedoc": "0.19.2",
+    "typescript": "4.1.3",
+    "winston": "3.3.3"
+>>>>>>> perf(Benchmarks): Add benchmarking script
   },
   "jest": {
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "/dist"
   ],
   "scripts": {
-    "format": "npx prettier --write './**/*.{md,ts}'",
+    "format": "npx prettier --write './**/*.{js,md,ts}'",
     "lint": "eslint 'index.ts' --fix",
     "test": "jest --runInBand",
     "test:cover": "jest  --runInBand --collectCoverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "node",
     "outDir": "./dist/lib"
   },
-  "files": ["index.ts"]
+  "files": ["index.ts", "index.d.ts"]
 }


### PR DESCRIPTION
I was recently evaluating whether we should continue to maintain Logga, or instead switch to using someone else's logging library. I decided that Logga has a useful combination of features that other libraries do not, and that we should indeed maintain it (but perhaps improve aspects).

As part of that evaluation I implemented some benchmarks and noticed that Logga had poor performance relative to other loggers:

```
bole x 667,896 ops/sec ±0.35% (93 runs sampled)
bunyan x 243,104 ops/sec ±0.27% (89 runs sampled)
logga x 28,811 ops/sec ±0.18% (97 runs sampled)
log4js x 155,397 ops/sec ±0.21% (96 runs sampled)
loglevel x 299,655 ops/sec ±0.38% (95 runs sampled)
pino x 664,888 ops/sec ±0.18% (94 runs sampled)
winston x 232,827 ops/sec ±4.53% (81 runs sampled)
```
It turned out that this was due to automatic stack generation feature (done for logged errors which are not passed an error). After removal of this "feature", performance was at least comparable to others:

```
bole x 657,008 ops/sec ±0.90% (93 runs sampled)
bunyan x 250,412 ops/sec ±0.27% (94 runs sampled)
logga x 253,980 ops/sec ±0.58% (97 runs sampled)
log4js x 143,212 ops/sec ±0.96% (93 runs sampled)
loglevel x 284,880 ops/sec ±0.39% (96 runs sampled)
pino x 671,490 ops/sec ±0.40% (93 runs sampled)
winston x 216,877 ops/sec ±5.55% (78 runs sampled)
```

I continued on the optimization train (see commits for details) until I got performance on par with the fastest of the other libraries:

```
bole x 793,786 ops/sec ±0.42% (92 runs sampled)
bunyan x 270,705 ops/sec ±0.41% (91 runs sampled)
logga x 798,245 ops/sec ±0.30% (94 runs sampled)
log4js x 213,667 ops/sec ±0.30% (92 runs sampled)
loglevel x 598,083 ops/sec ±0.37% (95 runs sampled)
pino x 696,967 ops/sec ±0.51% (92 runs sampled)
winston x 235,126 ops/sec ±6.26% (74 runs sampled)
```

Some time in the future I'd like to do some changes to the API and further optimizations may be possible along side those.
